### PR TITLE
initialize tsize option

### DIFF
--- a/src/parse_rrq.go
+++ b/src/parse_rrq.go
@@ -36,6 +36,7 @@ func sliceUpToNullByte(p []byte) ([]byte, []byte) {
 func ParseRequest(data []byte) (*Request, error) {
 	request := &Request{Blocksize: DEFAULT_BLOCKSIZE}
 	request.Opcode = binary.BigEndian.Uint16(data)
+	request.TransferSize = -1
 
 	if request.Opcode != RRQ {
 		return request, fmt.Errorf("Unknown optcode %d", request.Opcode)


### PR DESCRIPTION
The tsize option should only be returned when requested,
however users of the library have no easy way to detect requested options.

Initializing tsize to -1 makes it possible to detect clients that request tsize via 'tsize 0'.
