### PR TITLE
Use given local addr for outgoing response

### DIFF
--- a/src/parse_rrq.go
+++ b/src/parse_rrq.go
@@ -14,6 +14,7 @@ type Request struct {
 	Mode         int
 	Path         string
 	Addr         *net.Addr
+	LocalAddr    string
 }
 
 type RRQParseError struct {

--- a/src/rrq_response.go
+++ b/src/rrq_response.go
@@ -190,7 +190,7 @@ func (res *RRQresponse) End() (int, error) {
 
 func NewRRQresponse(clientaddr *net.UDPAddr, request *Request, badinternet bool) (*RRQresponse, error) {
 
-	listenaddr, err := net.ResolveUDPAddr("udp", ":0")
+	listenaddr, err := net.ResolveUDPAddr("udp", request.LocalAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/src/rrq_test.go
+++ b/src/rrq_test.go
@@ -49,6 +49,7 @@ func newRRQResonponse() (*RRQresponse, *MockConnection) {
 		-1,
 		"/foo",
 		nil,
+		"",
 	}
 	rrq := &RRQresponse{
 		conn,


### PR DESCRIPTION
When a server has multiple IP, disregarding which IP was used to make the
connection, the response will use the wildcard IP as source.

It cause some issues with some PXE firmware :

Example :
The TFTP server has IP 192.168.1.1 and 192.168.1.2. The primary IP is .1 but we
want to use .2 for the TFTP server.
The client has IP 192.168.1.3

The client sends a request 192.168.1.3 => 192.168.1.2 and the response is from
192.168.1.1. I have several machines which will reject this.

With this patch, if NewTFTPServer is called with a specific IP address, this IP
will be used as source for the responses.
If the wildcard is used, nothing will change

Example of tcpdump trace with the issue: 
https://www.dropbox.com/s/ytdy809cf2jtf1u/issue.dump?dl=0
