### PR TITLE
Close connection in res.End

### DIFF
--- a/src/rrq_response.go
+++ b/src/rrq_response.go
@@ -10,8 +10,12 @@ import (
 )
 
 type Connection interface {
+	SetReadDeadline(time.Time) error
 	ReadFrom(b []byte) (n int, addr net.Addr, err error)
+
+	SetWriteDeadline(time.Time) error
 	Write(p []byte) (n int, err error)
+
 	Close() (err error)
 }
 
@@ -24,6 +28,20 @@ type RRQresponse struct {
 	blocknum     uint16
 	badinternet  bool
 	TransferSize int
+}
+
+// readFrom sets a read timeout before calling res.conn.ReadFrom to ensure the
+// socket will be free'd if the client is disconnected.
+func readFrom(res *RRQresponse, b []byte) (int, net.Addr, error) {
+	res.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	return res.conn.ReadFrom(b)
+}
+
+// write sets a write timeout before calling res.conn.Write to ensure the
+// socket will be free'd if the client is disconnected.
+func write(res *RRQresponse, p []byte) (int, error) {
+	res.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	return res.conn.Write(p)
 }
 
 func (res *RRQresponse) SimulateBadInternet() bool {
@@ -78,13 +96,13 @@ func (res *RRQresponse) writeBuffer() (int, error) {
 		written = len(out)
 	} else {
 		var err error
-		written, err = res.conn.Write(out)
+		written, err = write(res, out)
 		if err != nil {
 			return 0, err
 		}
 	}
 
-	_, _, err := res.conn.ReadFrom(res.ack)
+	_, _, err := readFrom(res, res.ack)
 	if err != nil {
 		return 0, err
 	}
@@ -123,7 +141,7 @@ func (res *RRQresponse) WriteError(code uint16, message string) error {
 	copy(errorbuffer[4:], message)
 	errorbuffer[len(errorbuffer)-1] = 0
 
-	_, err := res.conn.Write(errorbuffer)
+	_, err := write(res, errorbuffer)
 	return err
 }
 
@@ -147,12 +165,12 @@ func (res *RRQresponse) WriteOACK() error {
 		oackbuffer = append(oackbuffer, 0)
 	}
 
-	_, err := res.conn.Write(oackbuffer)
+	_, err := write(res, oackbuffer)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = res.conn.ReadFrom(res.ack)
+	_, _, err = readFrom(res, res.ack)
 	if err != nil {
 		return err
 	}
@@ -178,7 +196,6 @@ func NewRRQresponse(clientaddr *net.UDPAddr, request *Request, badinternet bool)
 	}
 
 	conn, err := net.DialUDP("udp", listenaddr, clientaddr)
-
 	if err != nil {
 		return nil, err
 	}

--- a/src/rrq_response.go
+++ b/src/rrq_response.go
@@ -12,6 +12,7 @@ import (
 type Connection interface {
 	ReadFrom(b []byte) (n int, addr net.Addr, err error)
 	Write(p []byte) (n int, err error)
+	Close() (err error)
 }
 
 type RRQresponse struct {
@@ -162,6 +163,8 @@ func (res *RRQresponse) WriteOACK() error {
 }
 
 func (res *RRQresponse) End() (int, error) {
+	defer res.conn.Close()
+
 	// Signal end of the transmission. This can be neither empty block or
 	// block smaller than res.Request.Blocksize
 	return res.writeBuffer()

--- a/src/rrq_test.go
+++ b/src/rrq_test.go
@@ -5,11 +5,16 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 )
 
 type MockConnection struct {
 	datawritten [][]byte
 	closed      bool
+}
+
+func (conn *MockConnection) SetWriteDeadline(time.Time) error {
+	return nil
 }
 
 func (conn *MockConnection) Write(incoming []byte) (int, error) {
@@ -19,8 +24,7 @@ func (conn *MockConnection) Write(incoming []byte) (int, error) {
 	return len(incoming), nil
 }
 
-func (conn *MockConnection) Close() error {
-	conn.closed = true
+func (conn *MockConnection) SetReadDeadline(time.Time) error {
 	return nil
 }
 
@@ -29,6 +33,11 @@ func (conn *MockConnection) ReadFrom(p []byte) (n int, addr net.Addr, err error)
 	binary.BigEndian.PutUint16(p, ACK)
 	binary.BigEndian.PutUint16(p[2:], num)
 	return len(p), nil, nil
+}
+
+func (conn *MockConnection) Close() error {
+	conn.closed = true
+	return nil
 }
 
 func newRRQResonponse() (*RRQresponse, *MockConnection) {

--- a/src/rrq_test.go
+++ b/src/rrq_test.go
@@ -9,6 +9,7 @@ import (
 
 type MockConnection struct {
 	datawritten [][]byte
+	closed      bool
 }
 
 func (conn *MockConnection) Write(incoming []byte) (int, error) {
@@ -16,6 +17,11 @@ func (conn *MockConnection) Write(incoming []byte) (int, error) {
 	copy(data, incoming)
 	conn.datawritten = append(conn.datawritten, data)
 	return len(incoming), nil
+}
+
+func (conn *MockConnection) Close() error {
+	conn.closed = true
+	return nil
 }
 
 func (conn *MockConnection) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
@@ -46,6 +52,14 @@ func newRRQResonponse() (*RRQresponse, *MockConnection) {
 		-1,
 	}
 	return rrq, conn
+}
+
+func TestClosed(t *testing.T) {
+	rrq, conn := newRRQResonponse()
+	rrq.End()
+	if conn.closed != true {
+		t.Fatalf("Connection should be closed")
+	}
 }
 
 func TestSmallWrite(t *testing.T) {


### PR DESCRIPTION
The client's socket must be closed to avoid file descriptor leak, since
net.DialUDP is called in NewRRQresponse.

Go DialUDDP doc:

> DialUDP connects to the remote address raddr on the network net

From Linux's man 7 udp:

> When a UDP socket is created, its local and remote addresses are
> unspecified.  Datagrams can be sent immediately using sendto(2) or
> sendmsg(2) with a valid destination address as an argument.  When
> connect(2) is called on the socket, the default destination address is
> set and datagrams can now be sent using send(2) or write(2) without
> specifying a destination address.

This commit solves this issue https://github.com/tftp-go-team/hooktftp/issues/22
